### PR TITLE
Basic tag index

### DIFF
--- a/themes/timetree/assets/scss/pages/_global.scss
+++ b/themes/timetree/assets/scss/pages/_global.scss
@@ -44,7 +44,6 @@ body > header {
 }
 
 body > footer {
-  border-top: 1px dashed $line-color;
   height: $mobile_footer_height;
 
   @include for-desktop-up {

--- a/themes/timetree/assets/scss/pages/_global.scss
+++ b/themes/timetree/assets/scss/pages/_global.scss
@@ -56,7 +56,6 @@ a,
 a:link,
 a:hover,
 a:visited {
-  color: $body-bg-color;
   color: $body-fg-color;
   text-decoration: underline;
   text-decoration-color: #fecd70;

--- a/themes/timetree/assets/scss/pages/_home.scss
+++ b/themes/timetree/assets/scss/pages/_home.scss
@@ -119,3 +119,9 @@ body.home {
     display: none;
   }
 }
+
+// provisional styles to delimit leaves on tag list page
+article.container article {
+  padding-bottom: 12px;
+  border-bottom: 1px dashed $line-color;
+}

--- a/themes/timetree/layouts/_default/terms.html
+++ b/themes/timetree/layouts/_default/terms.html
@@ -4,7 +4,7 @@
       <section>
         <ul>
           {{ range $tag, $content := .Data.Terms }}
-          <li><a href="{{ .Page.Permalink }}">{{ $tag }}</a> ({{ $content.Count }})
+          <li><a href="{{ .Page.RelPermalink }}">{{ $tag }}</a> ({{ $content.Count }})
            </li>
           {{ end }}
         </ul>


### PR DESCRIPTION
in this pr:
- make tags in footer a link to tag list page
- add taxonomy term template page; display term and count only (don't display pages); link to pages with that term/tag
- minimal content styles to make leaf and tag list pages a bit more readable

## testing instructions:

view minimal tag index on PR render site at https://lenape-timetree-dev-pr-39.onrender.com/tags/

- [x] confirm that all tags are listed (as far as you can tell)
- [x] tags are listed in alphabetical order
- [x] each tag has a count listed and counts are accurate (as far as you can tell)
- [x] clicking a tag takes you to a list of leaves with that tag (layout and styles are provisional, just confirm you see the correct leaf content)
