### PR TITLE
Try percy min-height of 960

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -3,7 +3,7 @@ snapshot:
   widths:
     - 320
     - 1440
-  minHeight: 1024
+  minHeight: 960
   percyCSS: ""
 discovery:
   allowedHostnames: []


### PR DESCRIPTION
Updated percy config to set min-height to 960 (we had the default value of 1024). Please review percy snapshots (esp. mobile) and see if this is an improvement or causes any problems (on any screen size).