### PR TITLE
Display branches in the tree in the planned order; update leaf colors to separate similar shades

### DIFF
--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -46,8 +46,8 @@ const forceStrength = {
   branchX: 0.2, // draw to X coordinate based on branch
 
   // strength of link force by type of link
-  leafToLabel: 5.5, // between leaves and their labels
-  leafToBranch: 3, // between leaf and branch-century node
+  // leafToLabel: 5.5, // between leaves and their labels
+  leafToBranch: 3.75, // between leaf and branch-century node
   branchToBranch: 2.5, // between branch century nodes
 };
 
@@ -187,6 +187,7 @@ for (const branch in leavesByBranch) {
       }
     }
     // add the current leaf as a node
+    leaf.label = new LeafLabel(leaf.display_title || leaf.title);
     nodes.push(leaf);
     currentBranchNodeCount += 1;
     // add link between leaf and branch
@@ -341,8 +342,8 @@ function TreeGraph({ nodes, links, centuries }) {
         // collision radius should vary by node type
         if (d.type == "leaf") {
           return leafSize.width - 5;
-        } else if (d.type == "leaf-label") {
-          return d.label.radius - 10;
+          // } else if (d.type == "leaf-label") {
+          // return d.label.radius - 10;
         }
         return 2;
       })
@@ -417,9 +418,10 @@ function TreeGraph({ nodes, links, centuries }) {
 
   const nodeLabel = svg
     .append("g")
-    .attr("id", "labels")
+
     .selectAll("text")
-    .data(nodes.filter((d) => d.type == "leaf-label"))
+    // .data(nodes.filter((d) => d.type == "leaf-label"))
+    .data(nodes.filter((d) => d.type == "leaf"))
     .join("text")
     // x,y for a circle is the center, but for a text element it is top left
     // set position based on x,y adjusted by radius and height

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -103,7 +103,7 @@ sortedLeaves.forEach((leaf) => {
 
 // branches are defined and should be displayed in this order
 const branches = {
-  "Lands and Waters": "lands-waters",
+  "Lands + Waters": "lands-waters",
   Communities: "communities",
   "The University": "university",
   Removals: "removals",

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -97,16 +97,31 @@ sortedLeaves.forEach((leaf) => {
   }
 });
 
+// branches are defined and should be displayed in this order
+const branches = {
+  "Lands and Waters": "lands-waters",
+  Communities: "communities",
+  Removals: "removals",
+  "The University": "university",
+  "Resistance + Resurgence": "resistance-resurgence",
+};
+
 // group leaves by branch, preserving sort order
 let leavesByBranch = sortedLeaves.reduce((acc, leaf) => {
   let b = leaf.branch;
-  if (acc[b] == undefined) {
-    acc[b] = [];
+  // check that branch is in our list
+  if (b in branches) {
+    if (acc[b] == undefined) {
+      acc[b] = [];
+    }
+    acc[b].push(leaf);
+  } else {
+    // report unknown branchand omit from  the tree
+    console.log(`Unknown branch: ${b}`);
   }
-  acc[b].push(leaf);
   return acc;
 }, {});
-// console.log(leavesByBranch);
+console.log(leavesByBranch);
 
 // create a list to add nodes, starting with a node for the trunk
 let nodes = [
@@ -198,14 +213,10 @@ for (const branch in leavesByBranch) {
   });
 }
 // branch style color sequence; set class name and control with css
-let branchStyles = ["a", "b", "c", "d", "e"];
-
 function getBranchStyle(branchName) {
-  let branchIndex = Object.keys(leavesByBranch).indexOf(branchName);
-  // let branchIndex = Object.keys(branches).indexOf(branchName);
-  let branchStyle = branchStyles[branchIndex];
-  if (branchStyle != undefined) {
-    return "branch-" + branchStyles[branchIndex];
+  let branchSlug = branches[branchName];
+  if (branchSlug != undefined) {
+    return `branch-${branchSlug}`;
   }
 }
 

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -35,20 +35,20 @@ const d3 = {
 // strength of the various forces used to lay out the leaves
 const forceStrength = {
   // standard d3 forces
-  charge: -75, // simulate gravity (attraction) if the strength is positive, or electrostatic charge (repulsion) if the strength is negative
+  charge: -15, // simulate gravity (attraction) if the strength is positive, or electrostatic charge (repulsion) if the strength is negative
   manybody: -35, // A positive value causes nodes to attract each other, similar to gravity, while a negative value causes nodes to repel each other, similar to electrostatic charge; d3 default is -30
   center: 0.01, // how strongly drawn to the center of the svg
 
   // custom y force for century
-  centuryY: 10, // draw to Y coordinate for center of assigned century band
+  centuryY: 5, // draw to Y coordinate for center of assigned century band
 
   // custom x force for branch
-  branchX: 0.2, // draw to X coordinate based on branch
+  branchX: 0.05, // draw to X coordinate based on branch
 
   // strength of link force by type of link
   // leafToLabel: 5.5, // between leaves and their labels
-  leafToBranch: 3.75, // between leaf and branch-century node
-  branchToBranch: 2.5, // between branch century nodes
+  leafToBranch: 3.85, // between leaf and branch-century node
+  branchToBranch: 2, // between branch century nodes
 };
 
 // constant for selection classname
@@ -287,14 +287,13 @@ function TreeGraph({ nodes, links, centuries }) {
 
   // determine placement for branches left to right
   let branchCoords = {};
-  let branchMargin = 50;
+  let branchMargin = 100;
+  // etermine how much space to give to each branch
   let branchWidth = (width - branchMargin * 2) / 5;
-  console.log(branchWidth);
+  // calculate the midpoint of each branch and set for easy lookup
   for (const [i, b] of Object.keys(branches).entries()) {
-    // for (let [b, index] in branches) { // branches.forEach((b, i) => {
     branchCoords[b] = branchMargin + min_x + i * branchWidth + branchWidth / 2;
   }
-  console.log(branchCoords);
 
   // draw a couple of lines to help gesture at tree-ness
   let trunkWidth = 65;
@@ -341,7 +340,7 @@ function TreeGraph({ nodes, links, centuries }) {
       d3.forceCollide().radius((d) => {
         // collision radius should vary by node type
         if (d.type == "leaf") {
-          return leafSize.width - 5;
+          return leafSize.width; // - 5;
           // } else if (d.type == "leaf-label") {
           // return d.label.radius - 10;
         }

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -106,8 +106,8 @@ const branches = {
   "Lands and Waters": "lands-waters",
   Communities: "communities",
   Removals: "removals",
-  "The University": "university",
   "Resistance + Resurgence": "resistance-resurgence",
+  "The University": "university",
 };
 
 // group leaves by branch, preserving sort order

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -439,7 +439,7 @@ function TreeGraph({ nodes, links, centuries }) {
       // in the network simulation; probably needs some
       // adjusments, and should make sure these match
       if (d.type == "leaf-label") {
-        return leafSize.width - 5;
+        return d.label.radius - 10;
         // return d.label.radius;
       }
       if (d.type == "leaf") {

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -105,9 +105,9 @@ sortedLeaves.forEach((leaf) => {
 const branches = {
   "Lands and Waters": "lands-waters",
   Communities: "communities",
+  "The University": "university",
   Removals: "removals",
   "Resistance + Resurgence": "resistance-resurgence",
-  "The University": "university",
 };
 
 // group leaves by branch, preserving sort order

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -46,7 +46,6 @@ const forceStrength = {
   branchX: 0.05, // draw to X coordinate based on branch
 
   // strength of link force by type of link
-  // leafToLabel: 5.5, // between leaves and their labels
   leafToBranch: 3.85, // between leaf and branch-century node
   branchToBranch: 2, // between branch century nodes
 };
@@ -199,23 +198,6 @@ for (const branch in leavesByBranch) {
       value: forceStrength.leafToBranch,
       branch: leaf.branch,
     });
-
-    // add a label for the leaf
-    // nodes.push({
-    //   type: "leaf-label",
-    //   // display title takes precedence over title but is optional
-    //   label: new LeafLabel(leaf.display_title || leaf.title),
-    //   url: leaf.url,
-    //   id: leaf.id,
-    //   century: leaf.century,
-    //   tags: leaf.tags,
-    // });
-    // links.push({
-    //   source: leafIndex,
-    //   target: nodes.length - 1,
-    //   value: forceStrength.leafToLabel,
-    //   type: "leaf-label",
-    // });
   });
 }
 // branch style color sequence; set class name and control with css
@@ -338,11 +320,9 @@ function TreeGraph({ nodes, links, centuries }) {
     .force(
       "collide",
       d3.forceCollide().radius((d) => {
-        // collision radius should vary by node type
+        // collision radius varies by node type
         if (d.type == "leaf") {
           return leafSize.width; // - 5;
-          // } else if (d.type == "leaf-label") {
-          // return d.label.radius - 10;
         }
         return 2;
       })
@@ -353,9 +333,6 @@ function TreeGraph({ nodes, links, centuries }) {
         return link.value; // link strength defined when links created
       })
     )
-    // .force("link", d3.forceLink(links).distance(30).strength(link => {
-    // return 1;
-    // }))
     .force(
       "y",
       d3
@@ -415,11 +392,11 @@ function TreeGraph({ nodes, links, centuries }) {
     .on("mouseover", Leaf.highlightLeaf)
     .on("mouseout", Leaf.unhighlightLeaf);
 
+  // add text labels for leaves; position based on the leaf node
   const nodeLabel = svg
     .append("g")
-
+    .attr("id", "labels")
     .selectAll("text")
-    // .data(nodes.filter((d) => d.type == "leaf-label"))
     .data(nodes.filter((d) => d.type == "leaf"))
     .join("text")
     // x,y for a circle is the center, but for a text element it is top left
@@ -462,12 +439,12 @@ function TreeGraph({ nodes, links, centuries }) {
     .attr("dy", LeafLabel.lineHeight); // delta-y : relative position based on line height
 
   // visual debugging for layout
-  // draw circles and lines in a debug layer that can be shown or hidden
-  // circle size for leaf and leaf label matches radius used for collision
+  // draw circles and lines in a debug layer that can be shown or hidden;
+  // circle size for leaf matches radius used for collision
   // avoidance in the network layout
   debugLayer
     .selectAll("circle.debug")
-    .data(nodes) // .filter((d) => d.type == "leaf-label"))
+    .data(nodes)
     .join("circle")
     .attr(
       "class",
@@ -476,22 +453,15 @@ function TreeGraph({ nodes, links, centuries }) {
     .attr("cx", (d) => d.x)
     .attr("cy", (d) => d.y)
     .attr("r", (d) => {
-      // NOTE: we're currently adjusting collision radius slightly
-      // in the network simulation; probably needs some
-      // adjusments, and should make sure these match
-      if (d.type == "leaf-label") {
-        return d.label.radius - 10;
-        // return d.label.radius;
-      }
       if (d.type == "leaf") {
-        return leafSize.width - 5;
-        // return leafSize.width;
+        // return leafSize.width - 5;
+        return leafSize.width;
       }
       // note: this is larger than collision radius, increase size for visibility
       return 5; // for branch nodes
     });
 
-  // add lines for links to the debug layer
+  // add lines for links within the network to the debug layer
   const link = debugLayer
     .append("g")
     .selectAll("line")
@@ -500,7 +470,6 @@ function TreeGraph({ nodes, links, centuries }) {
     .attr("class", (d) => {
       return `${d.type || ""} dbg-${getBranchStyle(d.branch) || ""}`;
     });
-  // hide links to labels
 
   debugLayer
     .selectAll("line.debug-branch")

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -1,4 +1,4 @@
-import { select } from "d3-selection";
+import { select, selectAll } from "d3-selection";
 import {
   forceSimulation,
   forceManyBody,
@@ -17,6 +17,7 @@ import { LeafLabel } from "./labels";
 // combine into d3 object for convenience
 const d3 = {
   select,
+  selectAll,
   forceSimulation,
   forceManyBody,
   forceCenter,
@@ -54,11 +55,12 @@ const data = JSON.parse(leafData.value);
 
 // generate list of centuries referenced in the data; sort most recent first
 let centuries = Array.from(
-  new Set(
-    data.leaves
-      .filter((leaf) => leaf.century != undefined)
-      .map((leaf) => leaf.century)
-  )
+  data.leaves
+    .filter((leaf) => leaf.century != undefined)
+    .reduce((acc, leaf) => {
+      acc.add(leaf.century);
+      return acc;
+    }, new Set())
 )
   .sort()
   .reverse();
@@ -95,108 +97,117 @@ sortedLeaves.forEach((leaf) => {
   }
 });
 
-// our nodes will be all leaves plus nodes as needed for branches
-let nodes = new Array(...sortedLeaves);
-
-// create an object with all unique branch names from the leaves
-// and unique centuries represented within those branches
-let branches = new Object();
-sortedLeaves.forEach((leaf) => {
-  if (branches[leaf.branch] == undefined) {
-    branches[leaf.branch] = new Set();
+// group leaves by branch, preserving sort order
+let leavesByBranch = sortedLeaves.reduce((acc, leaf) => {
+  let b = leaf.branch;
+  if (acc[b] == undefined) {
+    acc[b] = [];
   }
-  // cast all to numeric to avoid duplication
-  branches[leaf.branch].add(Number(leaf.century));
-});
+  acc[b].push(leaf);
+  return acc;
+}, {});
+// console.log(leavesByBranch);
 
-// create a node for the trunk
-nodes.push({
-  id: "trunk",
-  title: "trunk",
-  type: "trunk",
-});
-const trunkNodeIndex = nodes.length - 1; // last node is the trunk
+// create a list to add nodes, starting with a node for the trunk
+let nodes = [
+  {
+    id: "trunk",
+    title: "trunk",
+    type: "trunk",
+  },
+];
+const trunkNodeIndex = 0; // first node is the trunk
 
+// array of links between our nodes
+let links = new Array();
+
+// add leaves to nodes by branch, in sequence,
+// creating branch+century nodes as we go
+for (const branch in leavesByBranch) {
+  // *in* for keys
+  let currentBranchNode;
+  let currentBranchNodeCount = 0;
+  let currentCentury;
+  let previousBranchIndex = trunkNodeIndex;
+  let branchIndex;
+  // for (const leaf of leavesByBranch[branch]) {  // *of* for values
+  leavesByBranch[branch].forEach((leaf, index) => {
+    // *of* for values
+    // check if we need to make a new branch node:
+    // - no node exists
+    // - too many leaves on current node
+    // - century has changed
+    if (
+      currentBranchNode == undefined ||
+      currentBranchNodeCount > 3 ||
+      currentCentury != leaf.century
+    ) {
+      let branchId = `${branch}-century${leaf.century}-${index}`;
+      let currentCentury = leaf.century;
+      currentBranchNodeCount = 0;
+      nodes.push({
+        id: `${branch}-century${leaf.century}-${index}`,
+        title: `${branch} ${leaf.century}century (${index})`,
+        type: "branch",
+        branch: branch,
+        century: leaf.century,
+      });
+      // add to links
+      branchIndex = nodes.length - 1;
+      // link to trunk or previous branch node
+      links.push({
+        source: previousBranchIndex,
+        target: branchIndex,
+        value: forceStrength.branchToBranch,
+        branch: branch,
+      });
+
+      if (branchIndex != undefined) {
+        previousBranchIndex = branchIndex;
+      }
+    }
+    // add the current leaf as a node
+    nodes.push(leaf);
+    currentBranchNodeCount += 1;
+    // add link between leaf and branch
+    // links.push(nodes.length - 1, branchIndex);
+    let leafIndex = nodes.length - 1;
+    links.push({
+      source: branchIndex,
+      target: leafIndex,
+      value: forceStrength.leafToBranch,
+      branch: leaf.branch,
+    });
+
+    // add a label for the leaf
+    nodes.push({
+      type: "leaf-label",
+      // display title takes precedence over title but is optional
+      label: new LeafLabel(leaf.display_title || leaf.title),
+      url: leaf.url,
+      id: leaf.id,
+      century: leaf.century,
+      tags: leaf.tags,
+    });
+    links.push({
+      source: leafIndex,
+      target: nodes.length - 1,
+      value: forceStrength.leafToLabel,
+      type: "leaf-label",
+    });
+  });
+}
 // branch style color sequence; set class name and control with css
 let branchStyles = ["a", "b", "c", "d", "e"];
 
 function getBranchStyle(branchName) {
-  let branchIndex = Object.keys(branches).indexOf(branchName);
+  let branchIndex = Object.keys(leavesByBranch).indexOf(branchName);
+  // let branchIndex = Object.keys(branches).indexOf(branchName);
   let branchStyle = branchStyles[branchIndex];
   if (branchStyle != undefined) {
     return "branch-" + branchStyles[branchIndex];
   }
 }
-
-// array of links between our nodes
-let links = new Array();
-
-// create nodes for the branches
-// - create one for each century represented in the data
-// - use text as id and label
-// NOTE: may want multiple century branch nodes when a single
-// branch has a large number of leaves in one century
-let branchIndex = new Object();
-let centuriesOldestFirst = Array.from(centuries).reverse();
-for (let branch in branches) {
-  centuriesOldestFirst.forEach((c, index) => {
-    let branchId = branch + c;
-    nodes.push({
-      id: branchId,
-      title: branch + " c" + c,
-      type: "branch",
-      century: c,
-    });
-    // keep track of branch indexes for generating links from leaves
-    branchIndex[branchId] = nodes.length - 1;
-
-    // add link to previous branch or trunk
-    if (index == 0) {
-      // earliest century in any branch should connect to trunk
-      target = trunkNodeIndex;
-    } else {
-      // otherwise, connect to preceding century in this branch
-      target = nodes.length - 2;
-    }
-    links.push({
-      source: branchIndex[branchId],
-      target: target,
-      value: forceStrength.branchToBranch,
-    });
-  });
-}
-
-// generate links so we can draw as a network graph
-// each leaf is connected to its branch+century node
-sortedLeaves.forEach((leaf, index) => {
-  let branchId = leaf.branch + leaf.century;
-  if (branchId in branchIndex) {
-    links.push({
-      source: index,
-      target: branchIndex[branchId],
-      value: forceStrength.leafToBranch,
-    });
-  }
-});
-
-// add nodes for labels, linked only to their corresponding leaf
-sortedLeaves.forEach((leaf, index) => {
-  nodes.push({
-    type: "leaf-label",
-    // display title takes precedence over title but is optional
-    label: new LeafLabel(leaf.display_title || leaf.title),
-    url: leaf.url,
-    id: leaf.id,
-    century: leaf.century,
-    tags: leaf.tags,
-  });
-  links.push({
-    source: index,
-    target: nodes.length - 1,
-    value: forceStrength.leafToLabel,
-    type: "leaf-label",
-  });
-});
 
 TreeGraph({ nodes: nodes, links: links, centuries: centuries });
 
@@ -222,10 +233,7 @@ function TreeGraph({ nodes, links, centuries }) {
   // create a section for the background
   let background = svg.append("g").attr("id", "background");
   // visual debugging layer
-  const debugLayer = svg
-    .append("g")
-    .attr("id", "debug")
-    .attr("visibility", "hidden");
+  const debugLayer = svg.append("g").attr("id", "debug").style("opacity", 0); // not visibly by default
 
   // create containers for the leaves by century
   const leafContainerHeight = 80;
@@ -316,16 +324,6 @@ function TreeGraph({ nodes, links, centuries }) {
       "link",
       d3.forceLink(links).strength((link) => {
         return link.value; // link strength defined when links created
-        // if (link.value != undefined) {
-        // return link.value;
-        // }
-        // alternately, could set based on source/target node type,
-        // or link type
-        // console.log(link);
-        // if (link.target.type == "leaf-label") {
-        //   return 5;
-        // }
-        // return 0.8
       })
     )
     // .force("link", d3.forceLink(links).distance(30).strength(link => {
@@ -345,19 +343,6 @@ function TreeGraph({ nodes, links, centuries }) {
   // only position once after simulation has run
   simulation.on("tick", ticked);
   simulation.tick();
-
-  // add lines for links to the debug layer
-  const link = debugLayer
-    .append("g")
-    .attr("stroke", "darkgray")
-    .attr("stroke-width", 1)
-    .selectAll("line")
-    .data(links)
-    .join("line")
-    .attr("stroke-opacity", (d) => {
-      return d.type == "leaf-label" ? 0 : 0.4;
-    });
-  // hide links to labels
 
   // define once an empty path for nodes we don't want to display
   var emptyPath = d3.line().curve(d3.curveNatural)([[0, 0]]);
@@ -400,6 +385,7 @@ function TreeGraph({ nodes, links, centuries }) {
     // set position based on x,y adjusted by radius and height
     .attr("x", (d) => d.x - d.label.radius)
     .attr("y", (d) => d.y - d.label.height / 2)
+    .attr("y", (d) => d.y - d.label.height / 2)
     .attr("data-id", (d) => d.id) // leaf id for url state
     .attr("data-url", (d) => d.url) // set url so we can click to select leaf
     .attr("text-anchor", "middle") // set coordinates to middle of text
@@ -435,32 +421,62 @@ function TreeGraph({ nodes, links, centuries }) {
     .attr("dy", LeafLabel.lineHeight); // delta-y : relative position based on line height
 
   // visual debugging for layout
-
-  // debug label placement + collision radius
-  //  draw a circle around each label with calculated radius
+  // draw circles and lines in a debug layer that can be shown or hidden
+  // circle size for leaf and leaf label matches radius used for collision
+  // avoidance in the network layout
   debugLayer
-    .selectAll("circle.debug-label")
-    .data(nodes.filter((d) => d.type == "leaf-label"))
+    .selectAll("circle.debug")
+    .data(nodes) // .filter((d) => d.type == "leaf-label"))
     .join("circle")
-    .attr("class", "debug-label")
+    .attr(
+      "class",
+      (d) => `debug debug-${d.type} dbg-${getBranchStyle(d.branch) || ""}`
+    )
     .attr("cx", (d) => d.x)
     .attr("cy", (d) => d.y)
-    .attr("r", (d) => d.radius)
-    .attr("stroke", "yellow")
-    .attr("fill", "transparent");
+    .attr("r", (d) => {
+      // NOTE: we're currently adjusting collision radius slightly
+      // in the network simulation; probably needs some
+      // adjusments, and should make sure these match
+      if (d.type == "leaf-label") {
+        return leafSize.width - 5;
+        // return d.label.radius;
+      }
+      if (d.type == "leaf") {
+        return leafSize.width - 5;
+        // return leafSize.width;
+      }
+      // note: this is larger than collision radius, increase size for visibility
+      return 5; // for branch nodes
+    });
 
-  // debug leaf placement + collision radius
-  //  draw a circle around each leaf with radius used for collision avoidance
-  debugLayer
-    .selectAll("circle.debug-leaf")
-    .data(nodes.filter((d) => d.type == "leaf"))
-    .attr("class", "debug-leaf")
-    .join("circle")
-    .attr("cx", (d) => d.x)
-    .attr("cy", (d) => d.y)
-    .attr("r", (d) => leafSize.width)
-    .attr("stroke", "cyan")
-    .attr("fill", "transparent");
+  // add lines for links to the debug layer
+  const link = debugLayer
+    .append("g")
+    .selectAll("line")
+    .data(links)
+    .join("line")
+    .attr("class", (d) => {
+      return `${d.type || ""} dbg-${getBranchStyle(d.branch) || ""}`;
+    });
+  // hide links to labels
+
+  // add debug controls
+  let debugLayerControls = {
+    // control id => layer id
+    "debug-visible": "#debug",
+    "leaf-visible": ".nodes",
+    "label-visible": "#labels",
+  };
+
+  // When the debug range inputs change, update the opacity for
+  //the corresponding layer
+  d3.selectAll("#debug-controls input").on("input", function () {
+    d3.selectAll(debugLayerControls[this.id]).style(
+      "opacity",
+      `${this.value}%`
+    );
+  });
 
   function ticked() {
     // node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);

--- a/content/leaves/assunpink.md
+++ b/content/leaves/assunpink.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: Ongoing
 display_title: Assunpink
 sort_date: 1500

--- a/content/leaves/b-calvin.md
+++ b/content/leaves/b-calvin.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1832
 display_title: B. Calvin
 sort_date: 1832

--- a/content/leaves/bethel-mission.md
+++ b/content/leaves/bethel-mission.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1746-1759
 display_title: Bethel Mission
 sort_date: 1746

--- a/content/leaves/brotherton-res.md
+++ b/content/leaves/brotherton-res.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1758
 display_title: Brotherton Res.
 sort_date: 1758

--- a/content/leaves/calvins.md
+++ b/content/leaves/calvins.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1754
 display_title: Calvins
 sort_date: 1754

--- a/content/leaves/concession.md
+++ b/content/leaves/concession.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1737
 sort_date: 1737
 tags:

--- a/content/leaves/delaware-valley.md
+++ b/content/leaves/delaware-valley.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1682-1776
 display_title: Delaware Valley
 sort_date: 1682

--- a/content/leaves/dutch-princeton.md
+++ b/content/leaves/dutch-princeton.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1737
 display_title: Dutch Princeton
 sort_date: 1737

--- a/content/leaves/dutch-settle.md
+++ b/content/leaves/dutch-settle.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1610
 display_title: Dutch Settle
 sort_date: 1610

--- a/content/leaves/easton-signing.md
+++ b/content/leaves/easton-signing.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1754 - 1763
 sort_date: 1754
 tags:

--- a/content/leaves/easton-treaty.md
+++ b/content/leaves/easton-treaty.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1758
 display_title: Easton Treaty
 sort_date: 1758

--- a/content/leaves/equality.md
+++ b/content/leaves/equality.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1682-1776
 sort_date: 1682
 tags:

--- a/content/leaves/europeans.md
+++ b/content/leaves/europeans.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1524-1609
 display_title: Europeans
 sort_date: 1524

--- a/content/leaves/kingston.md
+++ b/content/leaves/kingston.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1709
 sort_date: 1709
 tags:

--- a/content/leaves/land-seizure.md
+++ b/content/leaves/land-seizure.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1737
 sort_date: 1737
 tags:

--- a/content/leaves/lawsuit.md
+++ b/content/leaves/lawsuit.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Resistance + Resurgence
 display_date: 2006
 sort_date: 2006
 tags:

--- a/content/leaves/lenapewihittuck.md
+++ b/content/leaves/lenapewihittuck.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1600
 sort_date: 1600
 tags:

--- a/content/leaves/lunaapahkiing.md
+++ b/content/leaves/lunaapahkiing.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: Ongoing
 display_title: Lunaapahkiing
 sort_date: 1500

--- a/content/leaves/mannahatta.md
+++ b/content/leaves/mannahatta.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1624
 sort_date: 1624
 tags:

--- a/content/leaves/minisink.md
+++ b/content/leaves/minisink.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1600
 sort_date: 1600
 tags:

--- a/content/leaves/nj-purchase.md
+++ b/content/leaves/nj-purchase.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1677
 sort_date: 1677
 tags:

--- a/content/leaves/princeton-settlement.md
+++ b/content/leaves/princeton-settlement.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1683-1696
 display_title: Princeton settlement
 sort_date: 1683

--- a/content/leaves/shackamaxon-treaty.md
+++ b/content/leaves/shackamaxon-treaty.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1682
 sort_date: 1682
 tags:

--- a/content/leaves/walking-purchase.md
+++ b/content/leaves/walking-purchase.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1730
 sort_date: 1730
 tags:

--- a/content/leaves/westward-migration.md
+++ b/content/leaves/westward-migration.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1737
 sort_date: 1737
 tags:

--- a/content/leaves/wm-penn.md
+++ b/content/leaves/wm-penn.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1682
 display_title: Wm. Penn
 sort_date: 1682

--- a/content/leaves/yong.md
+++ b/content/leaves/yong.md
@@ -1,5 +1,5 @@
 ---
-branch: Lands and Waters
+branch: Lands + Waters
 display_date: 1634
 display_title: Yong
 sort_date: 1634

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,7 +26,8 @@
   </div>
 </aside>
 
-
+{{/* include visual debug controls unless this is a production build */}}
+{{ if not hugo.IsProduction }}
 <div id="debug-controls">
 <h2>Visual debug</h2>
 
@@ -45,11 +46,8 @@
   <input type="range" id="label-visible" name="label-visible"
          min="0" max="100" value="100">
   </label>
-
-
 </div>
-
-
+{{ end }}
 
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" defer></script>
 {{ end }} {{/* end main */}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,6 +27,30 @@
 </aside>
 
 
+<div id="debug-controls">
+<h2>Visual debug</h2>
+
+<p>Control layer visibility (0 - 100%)</p>
+
+<div>
+  <label>Debug
+  <input type="range" id="debug-visible" name="debug-visible"
+         min="0" max="100" value="0">
+  </label>
+  <label>Leaves
+  <input type="range" id="leaf-visible" name="leaf-visible"
+         min="0" max="100" value="100">
+  </label>
+  <label>Labels
+  <input type="range" id="label-visible" name="label-visible"
+         min="0" max="100" value="100">
+  </label>
+
+
+</div>
+
+
+
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" defer></script>
 {{ end }} {{/* end main */}}
 

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -86,9 +86,9 @@ body.home {
           stroke: map-get($leaf-outline-color, $branch);
           stroke-width: 3px;
           $glow: map-get($leaf-glow-color, $branch);
-          filter: drop-shadow(-6px -8px 16px $glow)
-            drop-shadow(6px 14px 16px $glow) drop-shadow(-9px 4px 16px $glow)
-            drop-shadow(9px 0px 16px $glow);
+          filter: drop-shadow(-3px -4px 8px $glow)
+            drop-shadow(3px 7px 8px $glow) drop-shadow(-4px 2px 8px $glow)
+            drop-shadow(4px 0px 8px $glow);
 
           outline: none; // disable browser default focus outline box
         }
@@ -107,17 +107,17 @@ body.home {
       /* branches should be ordered left to right as follows:
         - lands-waters
         - communities
-        - removals
         - university
+        - removals
         - resistance-resurgence
 
       map these branches to colors in this order to keep
       similar colors more separated:
 
         - lands-waters : c
-        - communities : b 
-        - removals : e
-        - university : d 
+        - communities : b
+        - university : e
+        - removals : d
         - resistance-resurgence : a
       */
 
@@ -127,10 +127,10 @@ body.home {
       .branch-communities {
         @include leaf-styles("b");
       }
-      .branch-removals {
+      .branch-university {
         @include leaf-styles("e");
       }
-      .branch-university {
+      .branch-removals {
         @include leaf-styles("d");
       }
       .branch-resistance-resurgence {
@@ -159,7 +159,10 @@ body.home {
 
     text.leaf-label {
       fill: $body-fg-color;
-      text-shadow: $nav-bg-color 2px 2px 2px, $nav-bg-color -2px -2px 2px;
+      // NOTE: previously had two shadows offset +/2px with 2px blur,
+      // but there's a Safari bug with multiple text shadows
+      // text-shadow: $nav-bg-color 2px 2px 2px, $nav-bg-color -2px -2px 2px;
+      text-shadow: $nav-bg-color 0px 0px 4px;
       // Hand cursor for leaf labels
       cursor: pointer;
     }
@@ -347,10 +350,10 @@ article.container article {
     &.dbg-branch-communities {
       stroke: map-get($leaf-color, "b");
     }
-    &.dbg-branch-removals {
+    &.dbg-branch-university {
       stroke: map-get($leaf-color, "e");
     }
-    &.dbg-branch-university {
+    &.dbg-branch-removals {
       stroke: map-get($leaf-color, "d");
     }
     &.dbg-branch-resistance-resurgence {
@@ -370,10 +373,10 @@ article.container article {
     &.dbg-branch-communities {
       stroke: map-get($leaf-outline-color, "b");
     }
-    &.dbg-branch-removals {
+    &.dbg-branch-university {
       stroke: map-get($leaf-outline-color, "e");
     }
-    &.dbg-branch-university {
+    &.dbg-branch-removals {
       stroke: map-get($leaf-outline-color, "d");
     }
     &.dbg-branch-resistance-resurgence {

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -117,8 +117,8 @@ body.home {
         - lands-waters : c
         - communities : b
         - university : e
-        - removals : d
-        - resistance-resurgence : a
+        - removals : a
+        - resistance-resurgence : d
       */
 
       .branch-lands-waters {
@@ -131,10 +131,10 @@ body.home {
         @include leaf-styles("e");
       }
       .branch-removals {
-        @include leaf-styles("d");
+        @include leaf-styles("a");
       }
       .branch-resistance-resurgence {
-        @include leaf-styles("a");
+        @include leaf-styles("d");
       }
 
       // hide nodes used for layout but not meant to be displayed
@@ -332,10 +332,10 @@ article.container article {
       fill: map-get($leaf-outline-color, "e");
     }
     &.dbg-branch-removals {
-      fill: map-get($leaf-outline-color, "d");
+      fill: map-get($leaf-outline-color, "a");
     }
     &.dbg-branch-resistance-resurgence {
-      fill: map-get($leaf-outline-color, "a");
+      fill: map-get($leaf-outline-color, "d");
     }
   }
 
@@ -354,10 +354,10 @@ article.container article {
       stroke: map-get($leaf-color, "e");
     }
     &.dbg-branch-removals {
-      stroke: map-get($leaf-color, "d");
+      stroke: map-get($leaf-color, "a");
     }
     &.dbg-branch-resistance-resurgence {
-      stroke: map-get($leaf-color, "a");
+      stroke: map-get($leaf-color, "d");
     }
   }
 
@@ -377,10 +377,10 @@ article.container article {
       stroke: map-get($leaf-outline-color, "e");
     }
     &.dbg-branch-removals {
-      stroke: map-get($leaf-outline-color, "d");
+      stroke: map-get($leaf-outline-color, "a");
     }
     &.dbg-branch-resistance-resurgence {
-      stroke: map-get($leaf-outline-color, "a");
+      stroke: map-get($leaf-outline-color, "d");
     }
 
     &.debug-branch {

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -281,3 +281,90 @@ article.container article {
   padding-bottom: 12px;
   border-bottom: 1px dashed $line-color;
 }
+
+// visual debug styles
+#debug {
+  circle {
+    fill: transparent; // override branch fill styles elsewhere
+  }
+  circle.debug-leaf-label {
+    stroke: yellow;
+  }
+  circle.debug-leaf {
+    stroke: cyan;
+  }
+  circle.debug-branch {
+    fill: lightgreen;
+
+    // color branch nodes based on the branch they belong to
+    // use outline colors since they are darker
+    &.dbg-branch-a {
+      fill: map-get($leaf-outline-color, "a");
+    }
+    &.dbg-branch-b {
+      fill: map-get($leaf-outline-color, "b");
+    }
+    &.dbg-branch-c {
+      fill: map-get($leaf-outline-color, "c");
+    }
+    &.dbg-branch-d {
+      fill: map-get($leaf-outline-color, "d");
+    }
+    &.dbg-branch-e {
+      fill: map-get($leaf-outline-color, "e");
+    }
+  }
+  line {
+    stroke: lightgray;
+    stroke-width: 1;
+    // could hide or adjust visibility depending on type of link
+
+    // color links within branch based on the branch they belong to
+    &.dbg-branch-a {
+      stroke: map-get($leaf-outline-color, "a");
+    }
+    &.dbg-branch-b {
+      stroke: map-get($leaf-outline-color, "b");
+    }
+    &.dbg-branch-c {
+      stroke: map-get($leaf-outline-color, "c");
+    }
+    &.dbg-branch-d {
+      stroke: map-get($leaf-outline-color, "d");
+    }
+    &.dbg-branch-e {
+      stroke: map-get($leaf-outline-color, "e");
+    }
+  }
+}
+
+#debug-controls {
+  position: absolute;
+  right: 0;
+  // position so it sits above the footer
+  top: calc(
+    100vh - #{$mobile_header_height} - #{$mobile_footer_height} - 175px;
+  );
+  padding: $margin;
+  height: 175px;
+
+  background-color: $lightgray;
+  color: $nearblack;
+  font-size: 80%;
+  label {
+    display: block;
+  }
+
+  input {
+    text-align: right;
+    padding-left: 5px;
+    width: 10em;
+  }
+
+  // customize range input slider
+  input[type="range"]::-webkit-slider-runnable-track,
+  input[type="range"]::-moz-range-track {
+    background: #053a5f;
+    height: 0.2rem;
+  }
+}

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -382,6 +382,10 @@ article.container article {
 }
 
 #debug-controls {
+  @include for-mobile {
+    display: none;
+  }
+
   position: absolute;
   right: 0;
   // position so it sits above the footer

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -104,20 +104,37 @@ body.home {
         }
       }
 
-      .branch-a {
-        @include leaf-styles("a");
-      }
-      .branch-b {
-        @include leaf-styles("b");
-      }
-      .branch-c {
+      /* branches should be ordered left to right as follows:
+        - lands-waters
+        - communities
+        - removals
+        - university
+        - resistance-resurgence
+
+      map these branches to colors in this order to keep
+      similar colors more separated:
+
+        - lands-waters : c
+        - communities : b 
+        - removals : e
+        - university : d 
+        - resistance-resurgence : a
+      */
+
+      .branch-lands-waters {
         @include leaf-styles("c");
       }
-      .branch-d {
+      .branch-communities {
+        @include leaf-styles("b");
+      }
+      .branch-removals {
+        @include leaf-styles("e");
+      }
+      .branch-university {
         @include leaf-styles("d");
       }
-      .branch-e {
-        @include leaf-styles("e");
+      .branch-resistance-resurgence {
+        @include leaf-styles("a");
       }
 
       // hide nodes used for layout but not meant to be displayed
@@ -288,52 +305,74 @@ article.container article {
     fill: transparent; // override branch fill styles elsewhere
   }
   circle.debug-leaf-label {
-    stroke: yellow;
+    stroke: $nearwhite;
   }
   circle.debug-leaf {
-    stroke: cyan;
+    // stroke: cyan;
   }
   circle.debug-branch {
-    fill: lightgreen;
-
-    // color branch nodes based on the branch they belong to
+    // color branch nodes based on the branch they belong to;
+    // they are smaller, so fill entirely.
     // use outline colors since they are darker
-    &.dbg-branch-a {
-      fill: map-get($leaf-outline-color, "a");
-    }
-    &.dbg-branch-b {
-      fill: map-get($leaf-outline-color, "b");
-    }
-    &.dbg-branch-c {
+    &.dbg-branch-lands-waters {
       fill: map-get($leaf-outline-color, "c");
     }
-    &.dbg-branch-d {
-      fill: map-get($leaf-outline-color, "d");
+    &.dbg-branch-communities {
+      fill: map-get($leaf-outline-color, "b");
     }
-    &.dbg-branch-e {
+    &.dbg-branch-removals {
       fill: map-get($leaf-outline-color, "e");
     }
+    &.dbg-branch-university {
+      fill: map-get($leaf-outline-color, "d");
+    }
+    &.dbg-branch-resistance-resurgence {
+      fill: map-get($leaf-outline-color, "a");
+    }
   }
+
+  // color circles for leaf markes based on their branch
+  // outline only, so we can see them around their leaves if both are displyaed
+  circle.debug-leaf {
+    stroke-width: 2;
+    // color links within branch based on the branch they belong to
+    &.dbg-branch-lands-waters {
+      stroke: map-get($leaf-color, "c");
+    }
+    &.dbg-branch-communities {
+      stroke: map-get($leaf-color, "b");
+    }
+    &.dbg-branch-removals {
+      stroke: map-get($leaf-color, "e");
+    }
+    &.dbg-branch-university {
+      stroke: map-get($leaf-color, "d");
+    }
+    &.dbg-branch-resistance-resurgence {
+      stroke: map-get($leaf-color, "a");
+    }
+  }
+
   line {
     stroke: lightgray;
     stroke-width: 1;
     // could hide or adjust visibility depending on type of link
 
     // color links within branch based on the branch they belong to
-    &.dbg-branch-a {
-      stroke: map-get($leaf-outline-color, "a");
-    }
-    &.dbg-branch-b {
-      stroke: map-get($leaf-outline-color, "b");
-    }
-    &.dbg-branch-c {
+    &.dbg-branch-lands-waters {
       stroke: map-get($leaf-outline-color, "c");
     }
-    &.dbg-branch-d {
+    &.dbg-branch-communities {
+      stroke: map-get($leaf-outline-color, "b");
+    }
+    &.dbg-branch-removals {
+      stroke: map-get($leaf-outline-color, "e");
+    }
+    &.dbg-branch-university {
       stroke: map-get($leaf-outline-color, "d");
     }
-    &.dbg-branch-e {
-      stroke: map-get($leaf-outline-color, "e");
+    &.dbg-branch-resistance-resurgence {
+      stroke: map-get($leaf-outline-color, "a");
     }
   }
 }

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -374,6 +374,10 @@ article.container article {
     &.dbg-branch-resistance-resurgence {
       stroke: map-get($leaf-outline-color, "a");
     }
+
+    &.debug-branch-x {
+      stroke-width: 3;
+    }
   }
 }
 

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -159,7 +159,7 @@ body.home {
 
     text.leaf-label {
       fill: $body-fg-color;
-      text-shadow: $nav-bg-color 2px 2px 2px;
+      text-shadow: $nav-bg-color 2px 2px 2px, $nav-bg-color -2px -2px 2px;
     }
 
     text {

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -325,10 +325,10 @@ article.container article {
     &.dbg-branch-communities {
       fill: map-get($leaf-outline-color, "b");
     }
-    &.dbg-branch-removals {
+    &.dbg-branch-university {
       fill: map-get($leaf-outline-color, "e");
     }
-    &.dbg-branch-university {
+    &.dbg-branch-removals {
       fill: map-get($leaf-outline-color, "d");
     }
     &.dbg-branch-resistance-resurgence {


### PR DESCRIPTION
in this pr:
- updates the tree so leaves are organized by branch in planned sequence from left to right
- revises colors so that similar colors are further apart
- place labels directly on top of the leaves instead of treating them as separate nodes within the network

This layout still needs some more refining (some leaves are going off the edges), but I think it's a lot more successful and we're heading in the right direction. In particular, the branches and centuries are much more accurate right now.

implementation details:
- I added a x-coordinate force to draw leaves to their branch location; right now I'm using a vertical line with an increasing force based on century (earlier leaves are less strongly drawn); we could revise to an angled line if necessary
- I'm drawing vertical lines on the debug mode so that you can see where the center of each branch is
- labels are now placed directly over the leaves, per Gissoo's suggestion; this simplified the code substantially

## testing notes 
@jhimpele please review on render site for this pr https://lenape-timetree-dev-pr-123.onrender.com/
- [x] confirm that leaves are more clearly separated by branch
- [x] confirm that color separation is better with this branch and color order
- [x] confirm that branch order follows the desired sequence left to right

