### PR TITLE
Update tag index to display label, link to tree with slug as tag param

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ params:
     An alternate view of the history of Princeton incorporating
     Lenape and indigenous events and perspectives
 
+# disable categories taxonomy included by default
+taxonomies:
+  tag: tags
+
 outputs:
   home:
     - HTML

--- a/themes/timetree/layouts/_default/terms.html
+++ b/themes/timetree/layouts/_default/terms.html
@@ -3,8 +3,9 @@
     <div>{{ .Content }}</div>
       <section>
         <ul>
-          {{ range $tag, $content := .Data.Terms }}
-          <li><a href="{{ .Page.RelPermalink }}">{{ $tag }}</a> ({{ $content.Count }})
+          {{ range .Data.Terms.Alphabetical }}
+          {{/* use the last portion of the permalink to get the slug for the tag */}}
+          <li><a href="{{ .Page.Site.BaseURL }}?tag={{ .Page.RelPermalink | path.Base }}">{{ .Page.Title }}</a> ({{ .Count }})
            </li>
           {{ end }}
         </ul>


### PR DESCRIPTION
ref #115

- revise tag index to show tag text as entered (mixed case, spaces)
- use tag permalink to generate link to timetree with slug version of the tag
- disable hugo default taxonomy of categories, which we are not using