### PR TITLE
Update project title to use the preferred spelling #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lenape Princeton Timetree
+# Lunaapahkiing Princeton Timetree
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Hugo](https://img.shields.io/badge/hugo-0.101-blue.svg)](https://gohugo.io)

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,14 @@
 baseURL: "http://example.org/"
 languageCode: en-us
-title: Lenape Princeton Timetree
+title: Lunaapahkiing Princeton Timetree
 theme: timetree
 paginate: 20
 
 params:
   description: >-
-    An alternate view of the history of Princeton incorporating
-    Lenape and indigenous events and perspectives
+    An interactive timetree displaying interwoven histories of the
+    Princeton University community and the Lenape peoples
+    of Lunaapahkiing, “the land of the Lenape.” .
 
 outputs:
   home:

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,8 @@
 ---
-title: Lenape Princeton Timetree
+title: Lunaapahkiing Princeton Timetree
+description: An interactive timetree displaying interwoven histories of the Princeton University community and the Lenape peoples of Lunaapahkiing, “the land of the Lenape.”
+
 ---
 
-introductory text explaining briefly about the project
+This timetree depicts the interwoven histories of the Lenape peoples of Lunaapahkiing, “the land of the Lenape,” and continuously since 1756, the Princeton University community. ...
+

--- a/themes/timetree/layouts/partials/head.html
+++ b/themes/timetree/layouts/partials/head.html
@@ -1,7 +1,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+    {{/* output page title before site title unless they are exactly the same */}}
+    <title>{{ block "title" . }}{{ with .Params.Title }}{{ if (ne . $.Site.Title) }}{{ . }} | {{ end }}{{ end }}{{ .Site.Title }}{{ end }}</title>
     <meta name="description" content="{{ .Params.Description | default .Summary | default .Site.Params.description }}">
     <!-- resource preloading -->
     <link rel="preload" as="font" type="font/woff2" href="/fonts/overlock/Overlock-Regular.woff2" crossorigin />


### PR DESCRIPTION

@gissoo want to make sure you're aware (I think you already are); I see on the Percy snapshots that the site title now requires too lines and the second is showing in our current styles.

## review
- [x] review site title on [render PR site](https://lenape-timetree-dev-pr-131.onrender.com) and confirm display is as expected/desired