### PR TITLE
Implement info button for mobile #85

### DIFF
--- a/assets/js/leaves.js
+++ b/assets/js/leaves.js
@@ -249,8 +249,6 @@ class Leaf {
 
   static closeLeafDetails() {
     const panel = document.querySelector("#leaf-details");
-    panel.parentElement.classList.remove("show-details");
-    panel.parentElement.classList.add("closed");
 
     Leaf.setCurrentLeaf();
     Leaf.closeTag();

--- a/assets/js/leaves.js
+++ b/assets/js/leaves.js
@@ -140,6 +140,9 @@ class Leaf {
     let tagID = url.searchParams.get("tag");
     let leafHash = url.hash;
 
+    // construct an object to track current state
+    let currentState = {};
+
     // deselect any current
     Leaf.deselectCurrent();
 
@@ -148,6 +151,7 @@ class Leaf {
       el.classList.remove(Leaf.selectedClass);
     });
     if (tagID) {
+      currentState.tag = tagID;
       let leaves = document.getElementsByClassName(tagID);
       for (let item of leaves) {
         item.classList.add(Leaf.highlightClass);
@@ -167,6 +171,7 @@ class Leaf {
     // (load leaf first so if there is a current tag it can be set to active)
     if (leafHash && leafHash.startsWith("#")) {
       let leafID = leafHash.slice(1);
+      currentState.leaf = leafID;
       let leafTarget = document.querySelector(`path[data-id=${leafID}]`);
       // if hash id corresponds to a leaf, select it
       if (leafTarget != undefined) {
@@ -176,6 +181,9 @@ class Leaf {
         Leaf.openLeafDetails(leafTarget, tagID);
       }
     }
+
+    // return an object indicating current state
+    return currentState;
   }
 
   static openLeafDetails(leafTarget, activeTag) {

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -24,10 +24,14 @@ class Panel {
   open(showDetails = true) {
     // open the panel; show leaf details by default
     // disable the info button
+    let container = this.el.parentElement;
     if (showDetails) {
-      this.el.parentElement.classList.add("show-details");
+      container.classList.add("show-details");
+    } else {
+      // when show details is not true, ensure leaf details are hidden
+      container.classList.remove("show-details");
     }
-    this.el.parentElement.classList.remove("closed");
+    container.classList.remove("closed");
     this.infoButton.disabled = true;
   }
 

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -10,7 +10,7 @@ class Panel {
 
     The class `closed`` is used to indicate the panel is closed
     (hidden on mobile, display introduction on desktop); the class
-    `show-details` is used to indicate whether leaf details are visible or not.`
+    `show-details` is used to indicate whether leaf details are visible or not.
 
     */
 
@@ -32,21 +32,34 @@ class Panel {
       container.classList.remove("show-details");
     }
     container.classList.remove("closed");
+    // disable the info button; inactive when the intro is visible
     this.infoButton.disabled = true;
   }
 
-  close() {
-    // close the panel and enable the info button
+  close(closeDetails = true) {
+    // close the intro and enable the info button
+    // by default, closes panel entireuly
     let container = this.el.parentElement;
-    container.classList.add("closed");
-    this.infoButton.disabled = false;
+    // determine if leaf details are currently displayed
+    let leafVisible = container.classList.contains("show-details");
 
-    // if leaf details are currently displayed, close that also
+    // if leaf details are visible and close details is true,
+    // deselct the leaf currently displayed, close that also,
+    // unless closeDetails has been disabled;
     // (has a side effect of also removing any currently selected tag)
-    if (container.classList.contains("show-details")) {
+    if (leafVisible && closeDetails) {
       container.classList.remove("show-details");
       Leaf.closeLeafDetails();
     }
+
+    // if we are closing everything or no leaf is visible, close the panel
+    if (closeDetails || !leafVisible) {
+      container.classList.add("closed");
+    }
+
+    // enable the info button;
+    // provides a way to get back to the intro on mobile
+    this.infoButton.disabled = false;
   }
 
   showIntro() {
@@ -54,6 +67,11 @@ class Panel {
     Leaf.closeLeafDetails();
     // open the panel without showing leaf details section
     this.open(false);
+  }
+
+  closeIntro() {
+    // close the panel without closing leaf details
+    this.close(false);
   }
 
   bindHandlers() {

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -50,8 +50,9 @@ class Panel {
   }
 
   showIntro() {
-    // special case: showing the intro means opening the panel
-    // but not showing leaf details section
+    // showing the intro implies closing leaf details (if a leaf is selected)
+    Leaf.closeLeafDetails();
+    // open the panel without showing leaf details section
     this.open(false);
   }
 

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -37,10 +37,16 @@ class Panel {
 
   close() {
     // close the panel and enable the info button
-    this.el.parentElement.classList.remove("show-details");
-    this.el.parentElement.classList.add("closed");
-    Leaf.closeLeafDetails();
+    let container = this.el.parentElement;
+    container.classList.add("closed");
     this.infoButton.disabled = false;
+
+    // if leaf details are currently displayed, close that also
+    // (has a side effect of also removing any currently selected tag)
+    if (container.classList.contains("show-details")) {
+      container.classList.remove("show-details");
+      Leaf.closeLeafDetails();
+    }
   }
 
   showIntro() {

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -1,28 +1,57 @@
 import { Leaf } from "./leaves";
 
 class Panel {
+  /*
+    The panel is used to display the project introduction on page load
+    and leaf details as leaves are selected.
+    On desktop, leaf details can be closed but the panel is always visible.
+    On mobile, the panel can be closed completely; there is an info
+    button to redisplay the project introduction.
+
+    The class `closed`` is used to indicate the panel is closed
+    (hidden on mobile, display introduction on desktop); the class
+    `show-details` is used to indicate whether leaf details are visible or not.`
+
+    */
+
   constructor() {
     // get a reference to the panel element
     this.el = document.querySelector("#leaf-details");
+    this.infoButton = document.querySelector("header .info");
     this.bindHandlers();
   }
 
+  open(showDetails = true) {
+    // open the panel; show leaf details by default
+    // disable the info button
+    if (showDetails) {
+      this.el.parentElement.classList.add("show-details");
+    }
+    this.el.parentElement.classList.remove("closed");
+    this.infoButton.disabled = true;
+  }
+
   close() {
-    // close the panel
+    // close the panel and enable the info button
     this.el.parentElement.classList.remove("show-details");
     this.el.parentElement.classList.add("closed");
     Leaf.closeLeafDetails();
+    this.infoButton.disabled = false;
+  }
+
+  showIntro() {
+    // special case: showing the intro means opening the panel
+    // but not showing leaf details section
+    this.open(false);
   }
 
   bindHandlers() {
     // bind click event handler for panel close button
-    let panel = this;
     document
       .querySelector("aside .close")
-      .addEventListener("click", (event) => {
-        // Close panel and deselect leaves
-        panel.close();
-      });
+      .addEventListener("click", this.close.bind(this));
+
+    this.infoButton.addEventListener("click", this.showIntro.bind(this));
 
     // bind keyboard handler
 

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -85,7 +85,12 @@ class TimeTree {
     // (currently needed to update active tag button)
     Leaf.tags = tags;
     // update selection to reflect active tag and/or leaf hash in url on page load
-    Leaf.updateSelection();
+    let status = Leaf.updateSelection();
+    // special case: if a tag is selected without a leaf on page load,
+    // hide the intro panel
+    if (status.tag && !status.leaf) {
+      this.panel.close();
+    }
   }
 
   getCenturies() {

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -86,10 +86,14 @@ class TimeTree {
     Leaf.tags = tags;
     // update selection to reflect active tag and/or leaf hash in url on page load
     let status = Leaf.updateSelection();
+
     // special case: if a tag is selected without a leaf on page load,
     // hide the intro panel
     if (status.tag && !status.leaf) {
       this.panel.close();
+    } else if (status.leaf) {
+      // if a leaf is selected on load, close the intro
+      this.panel.closeIntro();
     }
   }
 
@@ -405,7 +409,7 @@ class TimeTree {
         return classes.join(" ");
       })
       .on("click", (event) => {
-        this.panel.close(); // close so info button will be active on mobile
+        this.panel.closeIntro(); // close so info button will be active on mobile
         Leaf.setCurrentLeaf(event);
       })
       .on("mouseover", Leaf.highlightLeaf)
@@ -436,7 +440,7 @@ class TimeTree {
       })
       // .text((d) => d.label.text)
       .on("click", (event) => {
-        this.panel.close(); // close so info button will be active on mobile
+        this.panel.closeIntro(); // close so info button will be active on mobile
         Leaf.setCurrentLeaf(event);
       })
       .on("mouseover", Leaf.highlightLeaf)

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -399,7 +399,10 @@ class TimeTree {
         }
         return classes.join(" ");
       })
-      .on("click", Leaf.setCurrentLeaf)
+      .on("click", (event) => {
+        this.panel.close(); // close so info button will be active on mobile
+        Leaf.setCurrentLeaf(event);
+      })
       .on("mouseover", Leaf.highlightLeaf)
       .on("mouseout", Leaf.unhighlightLeaf);
 
@@ -427,7 +430,10 @@ class TimeTree {
         return classes.join(" ");
       })
       // .text((d) => d.label.text)
-      .on("click", Leaf.setCurrentLeaf)
+      .on("click", (event) => {
+        this.panel.close(); // close so info button will be active on mobile
+        Leaf.setCurrentLeaf(event);
+      })
       .on("mouseover", Leaf.highlightLeaf)
       .on("mouseout", Leaf.unhighlightLeaf);
 

--- a/themes/timetree/assets/scss/components/_panel.scss
+++ b/themes/timetree/assets/scss/components/_panel.scss
@@ -33,10 +33,19 @@ body.home main > aside {
 
   // allow closing the intro on mobile
   &.closed {
-    visibility: hidden;
+    height: 0;
+    #intro,
+    article,
+    > .close {
+      height: 0;
+    }
   }
   &.show-panel {
-    visibility: visible;
+    #intro,
+    article,
+    > .close {
+      height: auto;
+    }
   }
 
   @include for-desktop-up {
@@ -204,5 +213,13 @@ body.home main > aside {
         }
       }
     }
+  }
+}
+
+// special case: tag is active but intro panel is closed
+body.tag-active.home main > aside {
+  // panel should be exactly the height of the tag
+  &.closed {
+    height: $tag-height;
   }
 }

--- a/themes/timetree/assets/scss/components/_tags.scss
+++ b/themes/timetree/assets/scss/components/_tags.scss
@@ -84,3 +84,12 @@ $tag-color: (
     }
   }
 }
+
+.tag-active {
+  // when a tag is active, display the current tag button
+  // show even if the panel is closed on mobile
+  #current-tag,
+  aside.closed #current-tag {
+    opacity: 100%;
+  }
+}

--- a/themes/timetree/assets/scss/pages/_global.scss
+++ b/themes/timetree/assets/scss/pages/_global.scss
@@ -62,6 +62,30 @@ body > header {
   @include for-desktop-up {
     height: $desktop_header_height;
   }
+
+  /* info button for mobile */
+  .info {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 25px 25px;
+    opacity: 1;
+    cursor: pointer;
+
+    @include for-desktop-up {
+      visibility: hidden;
+    }
+
+    &[disabled] {
+      opacity: 0.3;
+      pointer-events: none;
+    }
+
+    i {
+      width: 24px;
+      height: 24px;
+    }
+  }
 }
 
 body > footer {

--- a/themes/timetree/assets/scss/pages/_timetree.scss
+++ b/themes/timetree/assets/scss/pages/_timetree.scss
@@ -191,11 +191,6 @@ body.home {
     opacity: 0.4;
     pointer-events: none;
   }
-
-  // when a tag is active, display the current tag button
-  #current-tag {
-    opacity: 100%;
-  }
 }
 
 // make link color visible

--- a/themes/timetree/layouts/partials/header.html
+++ b/themes/timetree/layouts/partials/header.html
@@ -6,4 +6,6 @@
       <img src="/img/site-title-mobile.svg" alt="{{ .Site.Title }}" width="184" height="68"/>
     </picture>
     {{ if eq .Title .Site.Title }}</h1>{{ end }}
+
+    <button class="info" aria-label="show intro" disabled><i class="ph-info" aria-hidden="true"></i></button>
 </header>

--- a/themes/timetree/layouts/partials/header.html
+++ b/themes/timetree/layouts/partials/header.html
@@ -1,11 +1,11 @@
 <header>
     {{/* when the page title is the sitle title, wrap project title in an h1 */}}
-    {{ if eq .Title .Site.Title }}<h1>{{ end }}
+    {{ if eq .Title .Site.Title }}<h1>{{ else }}<a href="{{ relURL "" }}">{{ end }}
     <picture>
       <source srcset="/img/site-title-desktop.svg" media="(min-width: 769px)" width="575" height="41"/>
       <img src="/img/site-title-mobile.svg" alt="{{ .Site.Title }}" width="184" height="68"/>
     </picture>
-    {{ if eq .Title .Site.Title }}</h1>{{ end }}
+    {{ if eq .Title .Site.Title }}</h1>{{ else }}</a>{{ end }}
 
     <button class="info" aria-label="show intro" disabled><i class="ph-info" aria-hidden="true"></i></button>
 </header>


### PR DESCRIPTION
## testing instructions
Open the render site for this PR on mobile: https://lenape-timetree-dev-pr-158.onrender.com/
- [x] when you load the page, an info button should be visible in the header but inactive/disabled
- [x] when you close the intro, the info button should become active; tapping it should display the intro again, and make the info button inactive again
- [x] if you select a leaf, the info button should become active; tapping it should display the intro and deselect the leaf
- [x] if you select a leaf, then select a tag, then tap the info button, you should see the intro; the leaf and tag should be deselected
- [x] go to the tag index page and choose a tag, so that you see the tree with the tag selected but no leaf active; the info button should be active; activating the button should deselect the tag and display the intro

check the render site on desktop:
- [x] info button should not be visible in the header