### PR TITLE
document draft status for leaves

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ Display title is optional, and can be used to set a shorter title for display
 in the timetree while using a longer, more detailed title in the leaf details.
 If not specified, title will be used for both and display_title may be omitted.
 
+### Unpublishing leaves
+
+If there is a leaf that needs to be pulled from the public site for some reason,
+but you don't want to delete the file entirely, you can mark it as a draft
+by adding `draft: true` to the metadata at the top of the file for that leaf.
+
 ### Adding images to leaves
 
 To include an image in the detailed description for a leaf:
@@ -77,10 +83,12 @@ are the same, only include the caption and source on the last image.
 #### Image sizes
 
 Portrait images:
+
 - Recommended min height: 1800px
 - Absolute min height: 864px
 
-Landscape images: 
+Landscape images:
+
 - Recommended min width: 1440px
 - Absolute min width: 700px
 

--- a/content/leaves/claim-vs-nj.md
+++ b/content/leaves/claim-vs-nj.md
@@ -8,6 +8,7 @@ tags:
 - treaties
 - colonial governments
 title: Public Grievance
+draft: true
 ---
 
 NJ Lunaapeew present grievances to the colony’s governor in Crosswicks, resulting in treaty agreements including “An Act for Regulating Indian Affairs, and to Prevent the Settling of Deer Traps within the Colony of New Jersey.” The conflicts underlying this meeting would resurface at the Treaty of Easton.


### PR DESCRIPTION
The only leaf I could find referencing "deer traps" was the one titled **Public Grievance** (filename `claim-vs-nj`, public title **Claim vs. NJ**); I've marked as a draft as part of this update 

## review notes 
- [x] look at files changed to see update to contributor documentation and draft status on claim-vs-nj file
- [x] look at the [timetree on the render site](https://lenape-timetree-dev-pr-216.onrender.com/) and confirm that the leaf is not included on the tree