### PR TITLE
Display labels for some leaves on mobile default view 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ Display title is optional, and can be used to set a shorter title for display
 in the timetree while using a longer, more detailed title in the leaf details.
 If not specified, title will be used for both and display_title may be omitted.
 
+### Featured leaves
+
+On mobile, only labels for featured leaves are displayed on the default view
+(when the tree is unzoomed). To mark a leaf as featured,
+add `featured: true` to the metadata for that leaf. This should be used
+sparingly!
+
 ### Unpublishing leaves
 
 If there is a leaf that needs to be pulled from the public site for some reason,

--- a/assets/js/timetree.js
+++ b/assets/js/timetree.js
@@ -558,6 +558,11 @@ class TimeTree extends TimeTreeKeysMixin(BaseSVG) {
         if (d.tags != undefined) {
           classes.push(...d.tags);
         }
+        // a few leaves are marked as featured to show labels
+        // on mobile when not zoomed
+        if (d.featured) {
+          classes.push("featured");
+        }
         return classes.join(" ");
       })
       // .text((d) => d.label.text)

--- a/content/leaves/american-indian-religious-freedom-act.md
+++ b/content/leaves/american-indian-religious-freedom-act.md
@@ -6,6 +6,7 @@ tags:
 - religion
 - alliances
 title: "\u201CAmerican Indian Religious Freedom Act\u201D"
+featured: true
 ---
 
 Enacted in 1978, the American Indian Religious Freedom Act protects Native Americans'  freedom to engage in traditional Indigenous religious and cultural practices, many of which the U.S. government had previously banned. The act also protects access and use of sites and sacred objects for such practices.

--- a/content/leaves/delaware-nation-in-oklahoma.md
+++ b/content/leaves/delaware-nation-in-oklahoma.md
@@ -11,6 +11,7 @@ tags:
 - Unami
 - Munsee
 title: Delaware Nation in Oklahoma
+featured: true
 ---
 
 Group of both Unami and Munsee speakers migrate further west to a settlement near what is today Cape Girardeau, Missouri, at the invitation of the Spanish (Cape Girardeau Delawares later settle in Texas and eventually end up on a reservation with Caddo and Wichita communities in present-day western Oklahoma – recognized today as Delaware Nation).

--- a/content/leaves/honorary-degree.md
+++ b/content/leaves/honorary-degree.md
@@ -7,6 +7,7 @@ tags:
 - US Government
 - recognition
 title: Dr. Kevin Gover
+featured: true
 ---
 
 Princeton’s first honorary degree conferred upon a Native American is given to Kevin Gover, a citizen of the Pawnee and Comanche Nations. Gover served as Assistant Secretary of the Interior for Indian Affairs under President Bill Clinton and later as director of the National Museum of the American Indian.

--- a/content/leaves/land-rights.md
+++ b/content/leaves/land-rights.md
@@ -8,6 +8,7 @@ tags:
 - redress
 - treaties
 title: Recovering New Jersey land rights
+featured: true
 ---
 
 1832: Descendants of Lunaapeew in Wisconsin successfully petition the State of New Jersey for compensation based on claims to lost fishing and hunting rights promised by the Treaty of Easton.

--- a/content/leaves/language-camp.md
+++ b/content/leaves/language-camp.md
@@ -6,6 +6,7 @@ sort_date: 2023
 tags:
 - language revitalization
 title: Lunaape Language Camp
+featured: true
 ---
 
 Munsee language teachers organize a Delaware (Lunaape) language camp with Princeton and IAS faculty. The gathering includes teachers from all of the Munsee-speaking nations, along with young adult community members who may become future teachers. The schedule includes traditional land-based learning, including time at the Seed Farm located in Princeton (which is a collaborative partnership with Ramapough Lunaape Nation members), as well as a half-day journey on the Millstone River, sharing Lunaape language, local history, and discussions of Indigenous sovereignty in today’s world.

--- a/content/leaves/midwest-resettlement.md
+++ b/content/leaves/midwest-resettlement.md
@@ -8,6 +8,7 @@ tags:
 - Iroquois
 - Ohio Country
 title: Midwest Resettlement
+featured: true
 ---
 
 A majority of Munsee and Unami speakers join villages along the Susquehanna, Allegheny, and Ohio rivers (known as Ohio Country) and are referred to collectively as the Delaware. Refugees are obliged to live as protectorates of the Six Nations/Iroquois. The Delawares experience pressure to centralize authority and elect a representative chief, which threatens their clan-based system of shared authority.

--- a/content/leaves/princeton-settlement.md
+++ b/content/leaves/princeton-settlement.md
@@ -7,6 +7,7 @@ tags:
 - Princeton lands
 - routes
 title: Greenland Tavern
+featured: true
 ---
 
 In 1683, the Henry Greenland Tavern is established along the Assunpink Trail, equidistant from the settlements of Philadelphia and New York. 1683 is the settlement date declared on the “Welcome to Princeton” signs today. Although the University declares that the “settlement” date is 1696, by then “Princeton” lands have been lived on for millennia by Lunaapeew.

--- a/content/leaves/pro-british-lunaapeew.md
+++ b/content/leaves/pro-british-lunaapeew.md
@@ -9,6 +9,7 @@ tags:
 - Unami
 - reservations
 title: Pro-British Lunaapeew
+featured: true
 ---
 
 Following the American Revolution, pro-British Lunaapeew migrate north and west to Canada and Spanish Territory in order to escape American retaliation; a few Northern Unami bands join the Iroquois on Six Nations Reserve along Grand River.

--- a/content/leaves/pro-british-lunaapeew.md
+++ b/content/leaves/pro-british-lunaapeew.md
@@ -9,7 +9,6 @@ tags:
 - Unami
 - reservations
 title: Pro-British Lunaapeew
-featured: true
 ---
 
 Following the American Revolution, pro-British Lunaapeew migrate north and west to Canada and Spanish Territory in order to escape American retaliation; a few Northern Unami bands join the Iroquois on Six Nations Reserve along Grand River.

--- a/content/leaves/removal-act.md
+++ b/content/leaves/removal-act.md
@@ -8,6 +8,7 @@ tags:
 - Indian Territory
 - dispossession
 title: Native Removal Act
+featured: true
 ---
 
 Under President Andrew Jackson, the Indian Removal Act empowers the U.S. Government with the policy and funds used to “persuade, bribe, and threaten” Indigenous peoples into land-exchange treaties (“removals”) for lands assigned to them in “Indian Territory” west of the Mississippi. See the Indian Removal Act Exhibit (https://prologue.blogs.archives.gov/2017/03/16/on-exhibit-the-indian-removal-act/)

--- a/content/leaves/walking-purchase.md
+++ b/content/leaves/walking-purchase.md
@@ -7,6 +7,7 @@ tags:
 - land claims
 - land purchases
 title: Walking Purchase
+featured: true
 ---
 
 By the 1730s, William Penn’s sons – Thomas and John – realize that Lunaape land could be used to resolve their great debts. With the help of a co-conspirator, John Logan, they produce an unsigned draft deed from 1686 in which Lunaapeew ostensibly promise to give up as much land as can be covered in a day and a half’s walk westward from the Delaware River in Bucks County.

--- a/content/leaves/witherspoon.md
+++ b/content/leaves/witherspoon.md
@@ -9,6 +9,7 @@ tags:
 - slavery
 - University presidents
 title: "Witherspoon\u2019s Reflections"
+featured: true
 ---
 
 As the sixth president of the College of NJ, John Witherspoon reflects on “experiment” of educating Native Americans: “On the whole it does not appear, that either by our people going among them, or by their being brought among us, that it is possible to give them a relish of civilized life. There have been some of them educated at this college, as well as in New England; but seldom if never did they ever prove good or useful.” Although Witherspoon held slaves, he supported their Christian instruction and education and he tutored two free African men.

--- a/layouts/partials/leaf_data.json
+++ b/layouts/partials/leaf_data.json
@@ -21,6 +21,9 @@
 		{{- with .Params.display_title -}}
 			{{- $pageInfo = merge $pageInfo (dict "display_title" . ) -}}
 		{{- end -}}
+		{{- with .Params.featured -}}
+			{{- $pageInfo = merge $pageInfo (dict "featured" . ) -}}
+		{{- end -}}
 		{{/* if sort date is numeric, calculate century */}}
 		{{- with .Params.sort_date -}} 		
 			{{- if (findRE `^\d+` .) -}}

--- a/themes/timetree/assets/scss/components/_zoom.scss
+++ b/themes/timetree/assets/scss/components/_zoom.scss
@@ -1,7 +1,7 @@
 body.home {
   svg {
     // on mobile at default zoom level, don't show labels
-    #labels {
+    #labels text {
       opacity: 0;
       transition: opacity 0.5s ease;
 
@@ -13,9 +13,22 @@ body.home {
   }
 
   // show labels when zoomed
-  .zoomed svg #labels {
+  .zoomed svg #labels text {
     opacity: 100%;
     pointer-events: auto;
+  }
+
+  // on mobile only, show labels for featured leaves when unzoomed
+  @include for-mobile {
+    // labels for featured leaves should be displayed when unzoomed
+    svg #labels text.featured {
+      opacity: 100%;
+    }
+
+    // increase font size for text when the tree is not zoomed
+    #timetree:not(.zoomed) text {
+      font-size: 20px;
+    }
   }
 
   #zoom-controls {

--- a/themes/timetree/assets/scss/components/_zoom.scss
+++ b/themes/timetree/assets/scss/components/_zoom.scss
@@ -48,7 +48,9 @@ body.home {
         display: inline-block;
       }
 
-      &[disabled="true"] {
+      // visual indication that buttons are disabled
+      &[disabled="true"],
+      &[disabled] {
         pointer-events: none;
         i {
           opacity: 0.2;


### PR DESCRIPTION
implementation for #195 

A few leaves have been marked as "featured" in the leaf metadata, based on a list provided by @jhimpele.  Labels for these leaves are now displayed on mobile at the default zoom level, with a slightly larger font size.

## testing instructions
https://lenape-timetree-dev-pr-228.onrender.com/
- [x] on mobile when the tree is not zoomed, only labels for featured leaves should be displayed
- [x] when you zoom in, all labels display (as before)

